### PR TITLE
Fix passing path to scanDirectory provided via upload command

### DIFF
--- a/dropbox-catalog/index.js
+++ b/dropbox-catalog/index.js
@@ -38,7 +38,7 @@ const readMetadata = async (filePath) => {
 }
 
 const scanDirectory = async (dir) => {
-    return await promisify(recursive)('./mp3');
+    return await promisify(recursive)(dir);
 }
 
 const uploadToDropbox = async (entry) => {
@@ -194,10 +194,8 @@ const mapToSongsCatalog = async (entry) => {
     }
 }
 
-
-
 if (argv._[0] === 'upload') {
-    scanDirectory(argv.file)
+    scanDirectory(argv.dir)
         .then(files => Promise.map(files, file => readMetadata(file)))
         .then(entries => Promise.map(entries, entry => uploadToDropbox(entry), { concurrency: 5 }))
         .then(entries => Promise.map(entries, entry => shareFromDropbox(entry), { concurrency: 5 }))


### PR DESCRIPTION
A reader of [your article](https://medium.com/@andreiciobanu_15529/build-your-own-music-streaming-service-with-amazon-alexa-41c7bf1eb66a) reported an issue parsing mp3's.

I had quick look, and it looks like there are some issues passing the upload folder,

Off-topic: @andrei-ace, please note that I also got a specialized module to read music-metadata from the S3 cloud in a pretty efficient way.