### PR TITLE
ask-v2 upgrade

### DIFF
--- a/.ask/ask-states.json.template
+++ b/.ask/ask-states.json.template
@@ -1,0 +1,30 @@
+{
+  "askcliStatesVersion": "2020-03-31",
+  "profiles": {
+    "default": {
+      "skillId": "YOUR-SKILL-ID",
+      "skillMetadata": {
+        "lastDeployHash": ""
+      },
+      "code": {
+        "default": {
+          "lastDeployHash": ""
+        }
+      },
+      "skillInfrastructure": {
+        "@ask-cli/lambda-deployer": {
+          "deployState": {
+            "default": {
+              "lambda": {
+                "arn": "YOUR-LAMBDA-ARN",
+                "lastModified": "",
+                "revisionId": ""
+              },
+              "iamRole": "YOUR-LAMBDA-IAM-ROLE-ARN"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .ask/config
+.ask/ask-states.json
+.ask/lambda/
 .env
+skill-package/skill.json
 node_modules/
 *.mp3
 artists.json

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Install ask-cli and initialize it
 ```
-$ npm install -g ask-cli
-$ ask-cli init
+$ npm install -g ask-cli@2
+$ ask init
 ```
 
 Install awscli
@@ -15,7 +15,7 @@ $ aws cloudformation deploy --template-file ./infrastructure/music-cloud.json --
 $ aws cloudformation describe-stacks --stack-name music-cloud-stack
 ```
 
-Edit .ask/config.template with your skill id and Lambda ARN (aws cloudformation describe-stacks)
+Edit .ask/config.template with your skill id and Lambda ARN (aws cloudformation describe-stacks) and rename to config
 
 Add Alexa Skills Kit trigger for the MusicCloudLambda 
 
@@ -23,7 +23,7 @@ To generate the catalog files:
 
 Install and configure awscli
 
-Create user, roles and DynamoDB table, Drobpbox token as described here: https://medium.com/@andreiciobanu_15529/build-your-own-music-streaming-service-with-amazon-alexa-41c7bf1eb66a
+Create Dropbox token as described here: https://medium.com/@andreiciobanu_15529/build-your-own-music-streaming-service-with-amazon-alexa-41c7bf1eb66a
 
 Edit .env.template with your Dropbox token and rename to .env
 ```
@@ -33,7 +33,25 @@ $ node index.js upload -d ./mp3/
 $ node index.js catalog
 ```
 
-Upload catalog files as described in the medium article
+Upload catalog files as described in the medium article. Note the following commands have changed when using version ask-cli@2:
+**Step 7**
+```
+# create the artist catalog
+$ ask smapi create-catalog --type AMAZON.MusicGroup --title catalog-artists --usage AlexaMusic.Catalog.MusicGroup
+# associate catalog to skill
+$ ask smapi associate-catalog-with-skill -s YOUR-SKILL-ID-HERE -c YOUR-ARTISTS-CATALOG-ID-HERE
+# upload artist catalog
+$ ask smapi upload-catalog -c YOUR-ARTISTS-CATALOG-ID-HERE -f ./dropbox-catalog/artists.json
+# now do the same for the song catalog
+$ ask smapi create-catalog --type AMAZON.MusicRecording --title catalog-songs --usage AlexaMusic.Catalog.MusicRecording
+$ ask smapi associate-catalog-with-skill -s YOUR-SKILL-ID-HERE -c YOUR-SONG-CATALOG-ID-HERE
+$ ask smapi upload-catalog -c YOUR-SONG-CATALOG-ID-HERE -f ./dropbox-catalog/songs.json
+```
+**Step 8**
+To check the status of a catalog upload you use this command
+```
+$ ask smapi get-content-upload-by-id -c YOUR-CATALOG-ID-HERE --upload-id YOUR-UPLOAD-ID-HERE
+```
 
 Deploy the skill and lambda
 ```

--- a/ask-resources.json
+++ b/ask-resources.json
@@ -1,0 +1,23 @@
+{
+  "askcliResourcesVersion": "2020-03-31",
+  "profiles": {
+    "default": {
+      "skillMetadata": {
+        "src": "./skill-package"
+      },
+      "code": {
+        "default": {
+          "src": "lambda/us-east-1_MusicCloudLambda/"
+        }
+      },
+      "skillInfrastructure": {
+        "type": "@ask-cli/lambda-deployer",
+        "userConfig": {
+          "runtime": "nodejs14.x",
+          "handler": "index.handler",
+          "awsRegion": "us-east-1"
+        }
+      }
+    }
+  }
+}

--- a/infrastructure/music-cloud.json
+++ b/infrastructure/music-cloud.json
@@ -82,7 +82,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "nodejs10.x",
+                "Runtime": "nodejs16.x",
                 "FunctionName": "MusicCloudLambda",
                 "MemorySize": 128,
                 "Timeout": 5,

--- a/skill-package/skill.json.template
+++ b/skill-package/skill.json.template
@@ -2,33 +2,30 @@
   "manifest": {
     "apis": {
       "music": {
-        "regions": {},
         "endpoint": {
-          "uri": "MusicCloudLambda",
-          "sourceDir": "lambda/us-east-1_MusicCloudLambda"
+          "uri": "YOUR-LAMBDA-ARN"
         },
         "interfaces": [
           {
             "namespace": "Alexa.Media.Playback",
-            "version": "1.0",
             "requests": [
               {
                 "name": "Initiate"
               }
-            ]
+            ],
+            "version": "1.0"
           },
           {
             "namespace": "Alexa.Media.Search",
-            "version": "1.0",
             "requests": [
               {
                 "name": "GetPlayableContent"
               }
-            ]
+            ],
+            "version": "1.0"
           },
           {
             "namespace": "Alexa.Audio.PlayQueue",
-            "version": "1.0",
             "requests": [
               {
                 "name": "GetNextItem"
@@ -36,12 +33,12 @@
               {
                 "name": "GetPreviousItem"
               }
-            ]
+            ],
+            "version": "1.0"
           }
         ],
         "locales": {
           "en-US": {
-            "promptName": "Music Cloud",
             "aliases": [
               {
                 "name": "music cloud"
@@ -53,7 +50,8 @@
                 "name": "cloud music"
               }
             ],
-            "features": []
+            "features": [],
+            "promptName": "Music Cloud"
           }
         }
       }


### PR DESCRIPTION
While working through deploying Music Cloud I opted to update to the ask-v2 implementation as the 1.0 ask API is not documented and obsolete on the AWS website. I tried to make minimal changes and document the new catalog commands in the README.md.